### PR TITLE
Create 'bundled' directory in web directories before compiling

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -3,6 +3,8 @@
 for dir in $@; do
     pushd $dir
 
+    mkdir -p bundled
+
     npm run compile
     npm run compile-test
 


### PR DESCRIPTION
When I ran `./setup.sh`, browserify seemed very unhappy that no `bundled` directories were present in each of the web directories.