### PR TITLE
Firebase persistence

### DIFF
--- a/angularWeb/main.js
+++ b/angularWeb/main.js
@@ -3,13 +3,20 @@ const {NgModule} = require("@angular/core")
 const {BrowserModule} = require("@angular/platform-browser")
 const {FormsModule} = require("@angular/forms")
 const {platformBrowserDynamic} = require("@angular/platform-browser-dynamic")
-const { UseCaseFactory, FakeRepoFactory } = require("rps")
+const { UseCaseFactory } = require("rps")
+const { provideFirebaseRepoFactory } = require("firebasePersist")
+
+let FirebaseRepoFactory = provideFirebaseRepoFactory(
+  "AIzaSyA811T0l1_v1utC7d8DFpZcYMlNfJC9nfo",
+  "https://rpstest-f3cba.firebaseio.com",
+  "testing123"
+)
 
 let RPSTestModule = NgModule({
     imports: [BrowserModule, FormsModule],
     declarations: [RPSApp],
     bootstrap: [RPSApp],
-    providers: [{provide: UseCaseFactory, useValue: new UseCaseFactory(new FakeRepoFactory())}]
+    providers: [{provide: UseCaseFactory, useValue: new UseCaseFactory(new FirebaseRepoFactory())}]
 }).Class({
     constructor(){
     }

--- a/angularWeb/package.json
+++ b/angularWeb/package.json
@@ -2,6 +2,7 @@
   "name": "angularWeb",
   "version": "0.0.0",
   "dependencies": {
+    "firebasePersist": "file:../firebasePersist",
     "rps": "file:../rps",
     "rpsPresentationI18n": "file:../rpsPresentationI18n",
     "@angular/core" : "4.0.0",

--- a/firebasePersist/package.json
+++ b/firebasePersist/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "firebasePersist",
+  "version": "0.0.0",
+  "files": ["src/"],
+  "main": "src/firebasePersist.js",
+  "dependencies": {
+    "rps": "file:../rps",
+    "firebase": "~3.7.4"
+  },
+  "devDependencies": {
+    "jasmine": "latest"
+  }
+}

--- a/firebasePersist/spec/FirebaseRoundRepoSpec.js
+++ b/firebasePersist/spec/FirebaseRoundRepoSpec.js
@@ -1,0 +1,17 @@
+const roundRepoContract = require("rps/spec/roundRepoContract")
+const provideFirebaseRepoFactory = require("./../src/FirebaseRepoFactory")
+
+roundRepoContract(provideFirebaseRepoFactory(
+  "AIzaSyA811T0l1_v1utC7d8DFpZcYMlNfJC9nfo",
+  "https://rpstest-f3cba.firebaseio.com",
+  function() {
+    return generateUUID()
+  }
+))
+
+function generateUUID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+}

--- a/firebasePersist/spec/support/jasmine.json
+++ b/firebasePersist/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/firebasePersist/src/FirebaseRepoFactory.js
+++ b/firebasePersist/src/FirebaseRepoFactory.js
@@ -1,0 +1,29 @@
+const FirebaseRoundRepo = require("./FirebaseRoundRepo")
+const firebase = require("firebase")
+
+let fb;
+
+function provideFirebaseRepoFactory(apiKey, databaseURL, databaseNameOrProvider) {
+  const FirebaseRepoFactory = function(){
+    this.roundRepo = function(){
+      if (fb === null || fb === undefined) {
+        fb = firebase.initializeApp({
+          apiKey: apiKey,
+          databaseURL: databaseURL
+        });
+      }
+
+      const databaseName = typeof databaseNameOrProvider === 'string' ?
+        databaseNameOrProvider :
+        databaseNameOrProvider()
+
+      round = new FirebaseRoundRepo(fb, databaseName)
+
+      return round
+    }
+  }
+
+  return FirebaseRepoFactory
+}
+
+module.exports = provideFirebaseRepoFactory

--- a/firebasePersist/src/FirebaseRoundRepo.js
+++ b/firebasePersist/src/FirebaseRoundRepo.js
@@ -1,0 +1,49 @@
+const { Round } = require("rps")
+
+function FirebaseRoundRepo(firebase, databaseName){
+  this.save = function(round){
+    return new Promise(function(resolve, reject) {
+      const sanitizedRound = stripUndefinedProperties(round)
+      getDatabaseRef().push(sanitizedRound).then(resolve, reject)
+    })
+  }
+
+  this.empty = function(){
+    return new Promise(function(resolve, reject) {
+      getDatabaseRef().once('value').then(function(snapshot) {
+        const savedRounds = snapshot.val();
+        const isEmpty = savedRounds === null;
+        resolve(isEmpty);
+      }, reject)
+    })
+  }
+
+  this.getAll = function() {
+    return new Promise(function(resolve, reject) {
+      getDatabaseRef().once('value').then(function (snapshot) {
+        let rounds = []
+
+        snapshot.forEach(function (child) {
+          const childValue = child.val();
+          rounds.push(new Round(
+            childValue.p1Throw,
+            childValue.p2Throw,
+            childValue.winner
+          ))
+        })
+
+        resolve(rounds)
+      });
+    });
+  }
+
+  function getDatabaseRef() {
+    return firebase.database().ref(databaseName + '/rounds/')
+  }
+}
+
+function stripUndefinedProperties(round) {
+  return JSON.parse(JSON.stringify(round))
+}
+
+module.exports = FirebaseRoundRepo

--- a/firebasePersist/src/FirebaseRoundRepo.js
+++ b/firebasePersist/src/FirebaseRoundRepo.js
@@ -2,24 +2,24 @@ const { Round } = require("rps")
 
 function FirebaseRoundRepo(firebase, databaseName){
   this.save = function(round){
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       const sanitizedRound = stripUndefinedProperties(round)
-      getDatabaseRef().push(sanitizedRound).then(resolve, reject)
+      getDatabaseRef().push(sanitizedRound).then(resolve)
     })
   }
 
   this.empty = function(){
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       getDatabaseRef().once('value').then(function(snapshot) {
         const savedRounds = snapshot.val();
         const isEmpty = savedRounds === null;
         resolve(isEmpty);
-      }, reject)
+      })
     })
   }
 
   this.getAll = function() {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       getDatabaseRef().once('value').then(function (snapshot) {
         let rounds = []
 

--- a/firebasePersist/src/firebasePersist.js
+++ b/firebasePersist/src/firebasePersist.js
@@ -1,0 +1,5 @@
+const provideFirebaseRepoFactory = require('./FirebaseRepoFactory')
+
+module.exports = {
+  provideFirebaseRepoFactory
+}

--- a/rps/spec/roundRepoContract.js
+++ b/rps/spec/roundRepoContract.js
@@ -9,7 +9,7 @@ function roundRepoContract(repoFactoryClass) {
         })
 
         it("saves rounds", function (done) {
-            let round = new Round()
+            let round = new Round("paper")
 
             repo.save(round)
                 .then(()=>repo.getAll())
@@ -30,7 +30,7 @@ function roundRepoContract(repoFactoryClass) {
 
         describe("when there are rounds", function () {
             it("is not empty", function (done) {
-                repo.save(new Round())
+                repo.save(new Round("paper"))
                     .then(()=>repo.empty())
                     .then((isEmpty)=> {
                         expect(isEmpty).toBeFalsy()


### PR DESCRIPTION
Seems I can't make a pull request for you to merge this into your own firebase-persistence branch, so I'll just target master and you can do what you want with it.

This is a Firebase backed implementation of the RoundRepo.  Since it requires connecting to an actual Firebase project, I've checked in the API key for a sandbox Firebase project I made so others can easily play with it.

Since the repo's state is actually persisted elsewhere, and the contract doesn't provide any way to reset or clear the repo, I setup my repo factory to allow either a database name, or a database name providing function.  This way, before each test, it just generates a new uuid for a database name that allows it to start fresh.  Would like feedback if there's a better way than how I did this.

Also had to make a change to the contract spec to have at least one of the round properties to be set, since Firebase won't story empty objects.  Probably could have avoided this with a smarter mapping, but it seemed to make sense to compare at least one field instead of just two objects with undefined properties.

I popped it into the angular web implementation, and it worked along with the webSpecs without any tweaks, which is great since the contact spec is doing its job properly.  Database name is hardcoded for that, so you will see what rounds others have entered.