### PR TITLE
Update instructions for installing browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a simple app that umpires a 2-person rock-paper-scissors games, and also
 
 Note that the setup and build scripts depend on the `yarn` package manager (an `npm` replacement). See the [yarn installation guide](https://yarnpkg.com/en/docs/install) if you don't already have yarn installed on your computer.
 
-They also assume "browserify" is globally installed. To do so, run `yarn install -g browserify`.
+They also assume "browserify" is globally installed. To do so, run `yarn global add browserify`.
 
 To set up all of the modules (i.e., `yarn install`, `yarn link`, `yarn run compile`, and `yarn run compile-test`), run `./setup.sh`
 


### PR DESCRIPTION
The command for global installation in yarn is now
`yarn global add <package>`