### PR TITLE
Fix norounds errors in reduxWeb and refluxWeb

### DIFF
--- a/reduxWeb/RPSApp.js
+++ b/reduxWeb/RPSApp.js
@@ -16,6 +16,10 @@ class RPSApp extends React.Component {
         this.props.useCases.history(this)
     }
 
+    norounds(rs){
+        this.props.dispatch({type: 'NO_ROUNDS'})
+    }
+
     rounds(rs){
         this.props.dispatch({type: 'ROUNDS', rounds: rs})
     }
@@ -103,6 +107,8 @@ const p2 = (state = '', action) => {
 
 const roundHistory = (state = 'NO ROUNDS', action) => {
     switch (action.type) {
+        case 'NO_ROUNDS':
+            return 'NO ROUNDS'
         case 'ROUNDS':
             return <RoundHistory rounds={action.rounds}/>
         default:

--- a/refluxWeb/RPSApp.js
+++ b/refluxWeb/RPSApp.js
@@ -53,6 +53,10 @@ class RPSApp extends Reflux.Component {
     }
 
     componentDidMount(){
+        this.updateHistory()
+    }
+
+    updateHistory() {
         this.props.useCases.history(this)
     }
 
@@ -63,22 +67,30 @@ class RPSApp extends Reflux.Component {
 
     p1Wins() {
         p1WinsAction()
+        this.updateHistory()
     }
 
     p2Wins() {
         p2WinsAction()
+        this.updateHistory()
     }
 
     tie() {
         tieAction()
+        this.updateHistory()
     }
 
     invalid() {
         invalidInputAction()
+        this.updateHistory()
     }
 
     rounds(rs) {
         roundsFoundAction(rs)
+    }
+
+    norounds() {
+        roundsFoundAction([])
     }
 
     render() {

--- a/webSpecs/src/webSpecs.js
+++ b/webSpecs/src/webSpecs.js
@@ -106,6 +106,22 @@ function webSpecs(createDOMFixture, mountApp) {
             })
         })
 
+        describe("when the history returns no results", function () {
+            let round
+
+            beforeEach(function (done) {
+                round = new Round("p1's Throw", "p2's Throw", "round winner")
+
+                renderApp({
+                    history: ui=>ui.norounds()
+                }, done)
+            })
+
+            it("shows nothing", function () {
+                // no errors thrown
+            })
+        })
+
         function page() {
             return document.querySelector("body").innerText
         }


### PR DESCRIPTION
The observer implementations in reduxWeb and refluxWeb didn't implement
the norounds method, which threw errors in the browser. Interestingly,
this appeared to prevent refluxWeb from rendering at all, but not
reduxWeb.

Different frontends handle norounds differently (some show a dedicated
message, some show nothing), so I added a test for the norounds case
with no assertions--it just ensures that no errors are thrown.

I also modified refluxWeb to update the history after a round is played.
Other frontends do this, although webSpecs doesn't require them to. I
opted not to add coverage for this.