### PR TITLE
Install elm dependencies automatically.

### DIFF
--- a/elmWeb/package.json
+++ b/elmWeb/package.json
@@ -19,9 +19,9 @@
     "webSpecs": "file:../webSpecs"
   },
   "scripts": {
-    "precompile": "elm make src/Main.elm --output bundled/ElmWeb.js",
+    "precompile": "elm make src/Main.elm --output bundled/ElmWeb.js --yes",
     "compile": "browserify main.js -o bundled/main.js -t [ babelify --presets [ es2015 ] --plugins [ transform-async-to-generator ] ]",
-    "precompile-test": "elm make src/Main.elm --output bundled/ElmWeb.js",
+    "precompile-test": "elm make src/Main.elm --output bundled/ElmWeb.js --yes",
     "compile-test": "browserify spec/webSpec.js -o bundled/compiledSpec.js -t [ babelify --presets [ es2015 ] --plugins [ transform-async-to-generator ] ]"
   }
 }


### PR DESCRIPTION
The compile and compile-test scripts bring up a prompt to install elm dependencies when they are missing. This interrupts the `./setup.sh` script.

This commit introduces the --yes flag to automatically respond yes to the prompt.

Also noticed that when I upgraded yarn the lockfile no longer gets updated on running the script, so it the behavior must have been fixed in the yarn issue you brought up in #7 